### PR TITLE
Fix welcome page link

### DIFF
--- a/prize-draw-app/resources/views/welcome.blade.php
+++ b/prize-draw-app/resources/views/welcome.blade.php
@@ -25,7 +25,7 @@
                 <nav class="flex items-center justify-end gap-4">
                     @auth
                         <a
-                            href="{{ url('/dashboard') }}"
+                            href="{{ route('home') }}"
                             class="inline-block px-5 py-1.5 dark:text-[#EDEDEC] border-[#19140035] hover:border-[#1915014a] border text-[#1b1b18] dark:border-[#3E3E3A] dark:hover:border-[#62605b] rounded-sm text-sm leading-normal"
                         >
                             Dashboard

--- a/prize-draw-app/routes/web.php
+++ b/prize-draw-app/routes/web.php
@@ -12,5 +12,6 @@ Auth::routes();
 
 Route::middleware('auth')->group(function () {
     Route::get('/home', [HomeController::class, 'index'])->name('home');
+    Route::get('/dashboard', [HomeController::class, 'index'])->name('dashboard');
     Route::get('/users', [UserController::class, 'index'])->name('users.index');
 });


### PR DESCRIPTION
## Summary
- make Dashboard link go to `home`
- add `/dashboard` route

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f3e084880833194a03d21e7c2be3f